### PR TITLE
Add 'random' for prop spawning

### DIFF
--- a/gamemode/sv_loot.lua
+++ b/gamemode/sv_loot.lua
@@ -144,6 +144,14 @@ local function getLootPrintString(data, plyPos)
 	return str
 end
 
+local function generate_random_key(t)
+    local keys = {}
+    for k, v in pairs(t) do
+        keys[#keys+1] = k
+    end
+    return keys[math.random(#keys)]
+end
+
 concommand.Add("mu_loot_add", function (ply, com, args, full)
 	if (!ply:IsAdmin()) then return end
 
@@ -156,12 +164,16 @@ concommand.Add("mu_loot_add", function (ply, com, args, full)
 
 	local name = args[1]:lower()
 	if !name:find("%.mdl$") then
-		if !LootModels[name] then
+		if name == "random" then
+			mdl = LootModels[generate_random_key(LootModels)]
+		elseif !LootModels[name] then
 			ply:ChatPrint("Invalid model alias " .. name)
 			return
+		else
+			mdl = LootModels[name]
 		end
 
-		mdl = LootModels[name]
+		
 	end
 
 


### PR DESCRIPTION
Makes it easier for people who are too lazy to type a different prop name each time (like me!)

I'm not sure if this is the /best/ method to do it, but LootModels[num] returns an error, so in my limited Lua knowledge I just googled around and found the idea for a key generator.

Command would be 'mu_loot_add random'
