### PR TITLE
Weapon names now translated in selection menu

### DIFF
--- a/entities/weapons/weapon_mu_knife/shared.lua
+++ b/entities/weapons/weapon_mu_knife/shared.lua
@@ -1,10 +1,12 @@
-SWEP.ViewModel = "models/weapons/v_knife_t.mdl"
-SWEP.WorldModel = "models/weapons/w_knife_t.mdl"
+SWEP.ViewModel 				= "models/weapons/v_knife_t.mdl"
+SWEP.WorldModel 			= "models/weapons/w_knife_t.mdl"
 
-SWEP.Weight	= 0
+SWEP.PrintName 				= translate and translate.knife or "Knife"
 
-SWEP.Spawnable			= true
-SWEP.AdminOnly			= true
+SWEP.Weight					= 0
+
+SWEP.Spawnable				= true
+SWEP.AdminOnly				= true
 
 SWEP.Primary.Delay			= 0.5
 SWEP.Primary.Recoil			= 3

--- a/entities/weapons/weapon_mu_knife/shared.lua
+++ b/entities/weapons/weapon_mu_knife/shared.lua
@@ -1,8 +1,6 @@
 SWEP.ViewModel = "models/weapons/v_knife_t.mdl"
 SWEP.WorldModel = "models/weapons/w_knife_t.mdl"
 
-SWEP.PrintName = translate and translate.knife or "Knife"
-
 SWEP.Weight	= 0
 
 SWEP.Spawnable			= true
@@ -28,6 +26,10 @@ SWEP.Secondary.ClipSize		= -1
 SWEP.Secondary.DefaultClip	= -1
 SWEP.Secondary.Automatic   	= false
 SWEP.Secondary.Ammo         = "none"
+
+function SWEP:Initialize()
+	self.PrintName = translate and translate.knife or "Knife"
+end
 
 function SWEP:GetTrace(left, up)
 	local trace = {}

--- a/entities/weapons/weapon_mu_magnum/shared.lua
+++ b/entities/weapons/weapon_mu_magnum/shared.lua
@@ -5,7 +5,6 @@ else
 end
 SWEP.Base = "weapon_base"
 
-SWEP.PrintName		= translate and translate.magnum or "Magnum"
 SWEP.Slot			= 2
 SWEP.SlotPos		= 1
 SWEP.DrawAmmo		= true
@@ -59,6 +58,7 @@ SWEP.Secondary.Automatic			= false
 SWEP.Secondary.Ammo					= "none"
 
 function SWEP:Initialize()
+	self.PrintName = translate and translate.magnum or "Magnum"
 	self:SetHoldType(self.HoldType)
 	self:SetCanAttack(true)
 end

--- a/entities/weapons/weapon_mu_magnum/shared.lua
+++ b/entities/weapons/weapon_mu_magnum/shared.lua
@@ -3,8 +3,9 @@ if ( SERVER ) then
 else
 	killicon.AddFont( "weapon_mu_magnum", "HL2MPTypeDeath", "1", Color( 255, 0, 0 ) )
 end
-SWEP.Base = "weapon_base"
+SWEP.Base 			= "weapon_base"
 
+SWEP.PrintName		= translate and translate.magnum or "Magnum"
 SWEP.Slot			= 2
 SWEP.SlotPos		= 1
 SWEP.DrawAmmo		= true

--- a/entities/weapons/weapon_rp_hands/shared.lua
+++ b/entities/weapons/weapon_rp_hands/shared.lua
@@ -6,7 +6,6 @@ if SERVER then
 	SWEP.AutoSwitchFrom		= false
 	
 else
-	SWEP.PrintName			= translate and translate.hands or "Hands"
 	SWEP.Slot				= 0
 	SWEP.SlotPos			= 1
 	SWEP.DrawAmmo			= false
@@ -47,6 +46,7 @@ SWEP.Secondary.Ammo			= "none"
 
 
 function SWEP:Initialize()
+	self.PrintName = translate and translate.hands or "Hands"
 	self:SetHoldType(self.HoldType)
 	self:DrawShadow(false)
 end

--- a/entities/weapons/weapon_rp_hands/shared.lua
+++ b/entities/weapons/weapon_rp_hands/shared.lua
@@ -6,6 +6,7 @@ if SERVER then
 	SWEP.AutoSwitchFrom		= false
 	
 else
+	SWEP.PrintName			= translate and translate.hands or "Hands"
 	SWEP.Slot				= 0
 	SWEP.SlotPos			= 1
 	SWEP.DrawAmmo			= false


### PR DESCRIPTION
Well, it's a strange behaviour.
Without initializing it in SWEP:Initialize() it wont translate.
Without keeping it in SWEP.PrintName it won't work.
Currently, i don't see the cause of it. Any info on it? Could be my fault somewhere.