### PR TITLE
Fix PR #42 - Error thrown by Pointshop 2 integration

### DIFF
--- a/gamemode/sv_rounds.lua
+++ b/gamemode/sv_rounds.lua
@@ -237,7 +237,7 @@ function GM:EndTheRound(reason, murderer)
 	self.MurdererLastKill = nil
 
 	hook.Call("OnEndRound")
-	hook.Call("OnEndRoundResult", reason)
+	hook.Run("OnEndRoundResult", reason)
 	self.RoundCount = self.RoundCount + 1
 	local limit = self.RoundLimit:GetInt()
 	if limit > 0 then


### PR DESCRIPTION
Resolves deadlock created by the second parameter passed to hook.Call. It has to be a gamemode table rather than parameters passed to the hook. Since we are calling a hook that is not part of the gamemode (table) it is better to use hook.Run in this case wich doesn't need an explicitly defined gamemode table.

This 'deadlock' caused "The murderer wins!" being spammed over and over again after round end and printed the mentioned error in the server console.