### PR TITLE
add korean and fix deadbody bug

### DIFF
--- a/gamemode/lang/korean.lua
+++ b/gamemode/lang/korean.lua
@@ -1,0 +1,115 @@
+pt.bystander = "시민"
+pt.murderer = "살인마"
+pt.spectator = "관전"
+
+pt.knife = "칼"
+pt.magnum = "매그넘"
+pt.gun = "총"
+pt.hands = "무장 해제"
+
+
+pt.teamSpectators = "관전자"
+pt.teamPlayers = "플레이어"
+pt.teamAss = "케이크"
+
+pt.killedTeamKill = "{player} 가 무고한 시민을 죽였습니다."
+pt.killedMurderer = "{player} 가 살인마를 죽였습니다."
+
+pt.murdererDeathUnknown = "살인마가 알수없는 이유로 죽었습니다." 
+
+pt.changeTeam = "{player} 님께서 {team} 팀으로 팀을 옮겼습니다."
+pt.teamMoved = "{player} 님이 {team} 팀으로 옮겨졌습니다. "
+pt.teamMovedAFK = "{player} 님께서 움직임이 없어 {team} 팀으로 옮겨졌습니다."
+
+pt.spectateFailed = "죽지 않았기 때문에 관전할수 없습니다."
+
+pt.murdererDisconnect = "살인마 중도 포기"
+pt.murdererDisconnectKnown = "살인마가 게임에서 나갔습니다, 살인마는 {murderer} 였습니다."
+
+pt.winBystanders = "시민 승리! "
+pt.winBystandersMurdererWas = "살인마는 {murderer} 였습니다."
+pt.winMurderer = "살인마 승리! "
+pt.winMurdererMurdererWas = "살인마는 {murderer} 였습니다."
+
+pt.minimumPlayers = "새 게임을 시작하기 위한 인원이 부족합니다."
+pt.roundStarted = "새로운 라운드가 시작됩니다."
+
+
+pt.adminMurdererSelect = "{player} 님이 다음 라운드에서 살인마가 됩니다."
+pt.adminMurdererForce = "강제로 다음 라운드 살인마 설정"
+pt.adminSpectate = "관전"
+pt.adminMoveToSpectate = "{spectate} 으로 옮기기"
+
+pt.mapChange = "{map} 으로 맵 교체중"
+
+pt.scoreboard = "점수판"
+pt.scoreboardName = "이름"
+pt.scoreboardPing = "핑"
+pt.scoreboardBystanderName = "시민 이름"
+pt.scoreboardStatus = "상태"
+pt.scoreboardChance = "기회"
+pt.scoreboardRefresh = "새로고침"
+
+pt.scoreboardJoinTeam = "참가"
+
+pt.scoreboardActionAdmin = "관리자"
+pt.scoreboardActionMute = "음소거"
+pt.scoreboardActionUnmute = "음소거 해제"
+pt.scoreboardActionViewProfile = "프로필 보기"
+
+pt.endroundMurdererQuit = "시민 승리! 살인마가 게임에서 나갔습니다"
+pt.endroundBystandersWin = "시민 승리!"
+pt.endroundMurdererWins = "살인마 승리!"
+pt.endroundMurdererWas = "살인마는 {murderer} 였습니다"
+
+pt.endroundLootCollected = "단서 수집 횟수"
+
+pt.adminPanel = "관리자 패널"
+
+pt.spectating = "관전중"
+
+pt.adMelonbomberWhy = "머더 게임모드의 제작자가 만든 "
+pt.adMelonbomberBy = " 한번 해보세요!"
+pt.voiceHelp = "도와줘!"
+pt.voiceHelpDescription = "도움을 요청"
+pt.voiceFunny = "농담"
+pt.voiceFunnyDescription = "농담 따먹기"
+pt.voiceScream = "비명"
+pt.voiceScreamDescription = "여자아이처럼 굴기"
+pt.voiceMorose = "괴로움"
+pt.voiceMoroseDescription = "슬픔을 느끼며"
+
+
+pt.startHelpBystanderTitle = "당신은 시민입니다."
+pt.startHelpBystander = {
+	"이곳에 살인마가 있습니다,",
+	"살해 당하지 마세요."
+}
+
+
+pt.startHelpGunTitle = "당신은 무기를 가진 시민입니다"
+pt.startHelpGunSubtitle = ""
+pt.startHelpGun = {
+	"이곳에 살인마가 있습니다,",
+	"모두가 죽기 전까지 찾아서 죽이세요."
+}
+
+pt.startHelpMurdererTitle = "당신은 살인마 입니다."
+pt.startHelpMurderer = {
+	"모두를 살해하되,",
+	"잡히지 마세요."
+}
+
+pt.murdererFog = "당신의 사악한 본능을 더이상 숨길수 없습니다."
+pt.murdererFogSub = "누군가를 죽여서 사악한 본능을 억제하세요."
+
+pt.pressEToDisguiseFor1Loot = "[E] 키를 눌러 단서 1개를 사용해 변장"
+
+pt.playerStatusDead = "사망"
+
+// ttt_traitor_button compatibility for TTT maps
+pt.ttt_tbut_single  = "일회용"
+pt.ttt_tbut_reuse   = "재사용 가능"
+pt.ttt_tbut_retime  = "{num} 초 후 재사용"
+pt.ttt_tbut_waittime  = "{timesec} 초 후 재사용 가능"
+pt.ttt_tbut_help    = "{key} 키를 눌러 사용하세요"

--- a/gamemode/sv_ragdoll.lua
+++ b/gamemode/sv_ragdoll.lua
@@ -45,7 +45,8 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 
 	local data = duplicator.CopyEntTable(self)
 	if !util.IsValidRagdoll(data.Model) then
-		return
+		data.Model = "models/player/skeleton.mdl"
+		// if use pointshop or something similar to handle character models, just return could be problem with disguise.
 	end
 
 	local ent = ents.Create( "prop_ragdoll" )


### PR DESCRIPTION
I added korean language and fixed deadbody bug.
use pointshop or something similar to handling character models, if deadbody's ragdoll model is invaild just return could be problem with disguise or anything.
so i added
data.Model = "models/player/skeleton.mdl"
that will make deadbody ragdoll even if it's invalid model
for advance, we can setting models depends on player's sex, instead skeleton. like using player spawn function. 

and this is my first pull request on github.. so i don't know about many. if i'm wrong something, i'm sorry that what i've done.