### PR TITLE
Improvements to the anti-propkill system

### DIFF
--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -136,11 +136,11 @@ end
 
 function GM:EntityTakeDamage( ent, dmginfo )
 	// disable all prop damage
-	if IsValid(dmginfo:GetAttacker()) && (dmginfo:GetAttacker():GetClass() == "prop_physics" || dmginfo:GetAttacker():GetClass() == "prop_physics_multiplayer") then
+	if IsValid(dmginfo:GetAttacker()) && (dmginfo:GetAttacker():GetClass() == "prop_physics" || dmginfo:GetAttacker():GetClass() == "prop_physics_multiplayer" || dmginfo:GetAttacker():GetClass() == "prop_physics_respawnable" || dmginfo:GetAttacker():GetClass() == "func_physbox") then
 		return true
 	end
 
-	if IsValid(dmginfo:GetInflictor()) && (dmginfo:GetInflictor():GetClass() == "prop_physics" || dmginfo:GetInflictor():GetClass() == "prop_physics_multiplayer") then
+	if IsValid(dmginfo:GetInflictor()) && (dmginfo:GetInflictor():GetClass() == "prop_physics" || dmginfo:GetInflictor():GetClass() == "prop_physics_multiplayer" || dmginfo:GetInflictor():GetClass() == "prop_physics_respawnable" || dmginfo:GetInflictor():GetClass() == "func_physbox") then
 		return true
 	end
 


### PR DESCRIPTION
Stops func_physbox and prop_physics_respawnable from being lethal props

These props are relatively rare, but still can be common occurrences. Notably, the table on house with garden v2 is a func_physbox and is, from personal experience, used extremely often to propkill. prop_physics_respawnables are used on ttt_island_2013 and derivatives.

This change will stop these types of entities from being used to propkill. Apologies for the messy one-liners; a for loop might be overkill in this scenario.