### PR TITLE
Remove an easy way to know who is the murderer

### DIFF
--- a/gamemode/sv_player.lua
+++ b/gamemode/sv_player.lua
@@ -132,16 +132,6 @@ function GM:DoPlayerDeath( ply, attacker, dmginfo )
 
 	ply:AddDeaths( 1 )
 
-	if ( attacker:IsValid() && attacker:IsPlayer() ) then
-
-		if ( attacker == ply ) then
-			attacker:AddFrags( -1 )
-		else
-			attacker:AddFrags( 1 )
-		end
-
-	end
-
 end
 
 local plyMeta = FindMetaTable("Player")


### PR DESCRIPTION
Score gets increased by 1 when you kill someone. By tracking this score via Steam's "View Game Info" or other sources (eg. GameTracker) you can determine when someone killed somebody. Although you can get only Steam name with this method, it's still a problem because you may be able to determine player's in-game name if they're using microphone.

Found by [wow?](https://steamcommunity.com/profiles/76561198338757497/)
He was able to use it to determine the murderer at the beginnings of rounds.