### PR TITLE
Set round status after setting up players

### DIFF
--- a/gamemode/sv_rounds.lua
+++ b/gamemode/sv_rounds.lua
@@ -272,7 +272,6 @@ function GM:StartNewRound()
 	ct:Add(translate.roundStarted)
 	ct:SendAll()
 
-	self:SetRound(self.Round.Playing)
 	self.RoundUnFreezePlayers = CurTime() + 10
 
 	local players = team.GetPlayers(2)
@@ -344,6 +343,7 @@ function GM:StartNewRound()
 
 	self.MurdererLastKill = CurTime()
 
+	self:SetRound(self.Round.Playing)
 	hook.Call("OnStartRound")
 end
 


### PR DESCRIPTION
The player setup routine includes killing and respawning
all players, but at that time, the round status has been
set to "RUNNING" already.

That behaviour might cause problems for plugins that want
to do stuff on player death, but only if the round is in
progress (which it isn't yet).

Change the order of commands so that the round is only
set to run after all the setup has been done.