### PR TITLE
Fix freeze cam

### DIFF
--- a/gamemode/sv_player.lua
+++ b/gamemode/sv_player.lua
@@ -375,7 +375,7 @@ function GM:PlayerOnChangeTeam(ply, newTeam, oldTeam)
 	end
 	ply:SetMurderer(false)
 	if newteam == 1 then
-		
+		ply:Freeze(false)
 	end
 	ply.HasMoved = true
 	ply:KillSilent()


### PR DESCRIPTION
If in round start player join in "Spectators" team his camera remained frozen. This has been fixed here