### PR TITLE
fix: loading map loot.txt file properly

### DIFF
--- a/gamemodes/murder/commands.txt
+++ b/gamemodes/murder/commands.txt
@@ -13,7 +13,7 @@ Loot
 	mu_loot_remove - Removes loot spawn with specified id
 	mu_loot_adjustpos - Sets the loot spawn position to the current position of the loot object you are looking at 
 	mu_loot_respawn - Respawns all loot
-	mu_loot_reload <path> - Reloads all loot data for this map. <path> is optional, use --data to load from the "data" directory, and --static for "data_static"
+	mu_loot_reload <path> - Reloads all loot data for this map. <path> is optional, use --data to load from the "data" directory, "--embedded" for data mounted from the addon, and --static for "data_static"
 	mu_loot_models_list - Lists all model aliases, these can be used instead of model filenames in mu_loot_add
 
 Misc

--- a/gamemodes/murder/commands.txt
+++ b/gamemodes/murder/commands.txt
@@ -13,6 +13,7 @@ Loot
 	mu_loot_remove - Removes loot spawn with specified id
 	mu_loot_adjustpos - Sets the loot spawn position to the current position of the loot object you are looking at 
 	mu_loot_respawn - Respawns all loot
+	mu_loot_reload <path> - Reloads all loot data for this map. <path> is optional, use --data to load from the "data" directory, and --static for "data_static"
 	mu_loot_models_list - Lists all model aliases, these can be used instead of model filenames in mu_loot_add
 
 Misc

--- a/gamemodes/murder/gamemode/sv_loot.lua
+++ b/gamemodes/murder/gamemode/sv_loot.lua
@@ -44,10 +44,15 @@ local FruitModels = {
 util.AddNetworkString("GrabLoot")
 util.AddNetworkString("SetLoot")
 
+local printFailOutput = false
+local function printFail(msg)
+	if printFailOutput then print(msg) end
+end
+
 local function loadLootFileInDir(fileDir)
 	local filePath = fileDir.."/loot.txt"
 	if not file.Exists(filePath, "GAME") then
-		print(filePath.." does not exist")
+		printFail(filePath.." does not exist")
 		return false
 	end
 
@@ -60,11 +65,15 @@ local function loadLootFileInDir(fileDir)
 		return true
 	end
 
-	print("Data inside "..filePath.." seems to be corrupted")
+	printFail("Data inside "..filePath.." seems to be corrupted")
 	return false
 end
 
-local function runLootReload(pathArg)
+local function runLootReload(pathArg, printOutput)
+	if printOutput then 
+		printFailOutput = printOutput 
+	end
+
 	local map = game.GetMap()
 	if (map == "menu") then return end
 
@@ -87,7 +96,7 @@ local function runLootReload(pathArg)
 end
 
 function GM:LoadLootData() 
-	runLootReload()
+	runLootReload(nil, false)
 end
 
 function GM:CountLootItems()
@@ -224,7 +233,7 @@ concommand.Add("mu_loot_reload", function(ply, com, args, full)
 		pathArg = args[1]
 	end
 
-	runLootReload(pathArg)
+	runLootReload(pathArg, true)
 end)
 
 concommand.Add("mu_loot_add", function (ply, com, args, full)

--- a/gamemodes/murder/gamemode/sv_loot.lua
+++ b/gamemodes/murder/gamemode/sv_loot.lua
@@ -44,13 +44,48 @@ local FruitModels = {
 util.AddNetworkString("GrabLoot")
 util.AddNetworkString("SetLoot")
 
-function GM:LoadLootData() 
-	local mapName = game.GetMap()
-	local jason = file.ReadDataAndContent("murder/" .. mapName .. "/loot.txt")
-	if jason then
-		local tbl = util.JSONToTable(jason)
-		LootItems = tbl
+local function loadLootFileInDir(fileDir)
+	local filePath = fileDir.."/loot.txt"
+	if not file.Exists(filePath, "GAME") then
+		print(filePath.." does not exist")
+		return false
 	end
+
+	local json = file.Read(filePath, "GAME")
+	local content = util.JSONToTable(json)
+
+	if json then
+		LootItems = content
+		print("Successfully loaded loot data from "..filePath.."!")
+		-- 		PrintTable(LootItems)
+		return true
+	end
+
+	print("Data inside "..filePath.." seems to be corrupted")
+	return false
+end
+
+local function runLootReload(pathArg)
+	local map = game.GetMap()
+	if (map == "menu") then return end
+
+	local dataPath = "data/murder/"..map
+	local staticPath = "data_static/murder/"..map
+
+	if not pathArg then
+		if loadLootFileInDir(dataPath) then return end
+		if loadLootFileInDir(staticPath) then return end
+		print("No loot data file found to load!")
+		return
+	end
+
+	if pathArg == "--data" then loadLootFileInDir(dataPath)
+	elseif pathArg == "--static" then loadLootFileInDir(staticPath)
+	else print("Invalid path argument!") end
+end
+
+function GM:LoadLootData() 
+	runLootReload()
 end
 
 function GM:CountLootItems()
@@ -178,6 +213,17 @@ local function getLootPrintString(data, plyPos)
 	str = str .. " " .. data.model
 	return str
 end
+
+concommand.Add("mu_loot_reload", function(ply, com, args, full)
+	if (not ply:IsAdmin()) then return end
+
+	local pathArg = nil
+	if #args >= 1 then
+		pathArg = args[1]
+	end
+
+	runLootReload(pathArg)
+end)
 
 concommand.Add("mu_loot_add", function (ply, com, args, full)
 	if (!ply:IsAdmin()) then return end

--- a/gamemodes/murder/gamemode/sv_loot.lua
+++ b/gamemodes/murder/gamemode/sv_loot.lua
@@ -57,7 +57,6 @@ local function loadLootFileInDir(fileDir)
 	if json then
 		LootItems = content
 		print("Successfully loaded loot data from "..filePath.."!")
-		-- 		PrintTable(LootItems)
 		return true
 	end
 
@@ -70,16 +69,19 @@ local function runLootReload(pathArg)
 	if (map == "menu") then return end
 
 	local dataPath = "data/murder/"..map
+	local embeddedPath = "gamemodes/murder/content/data/murder/"..map
 	local staticPath = "data_static/murder/"..map
 
 	if not pathArg then
 		if loadLootFileInDir(dataPath) then return end
+		if loadLootFileInDir(embeddedPath) then return end
 		if loadLootFileInDir(staticPath) then return end
 		print("No loot data file found to load!")
 		return
 	end
 
 	if pathArg == "--data" then loadLootFileInDir(dataPath)
+	elseif pathArg == "--embedded" then loadLootFileIndir(embedPath)
 	elseif pathArg == "--static" then loadLootFileInDir(staticPath)
 	else print("Invalid path argument!") end
 end

--- a/gamemodes/murder/gamemode/sv_loot.lua
+++ b/gamemodes/murder/gamemode/sv_loot.lua
@@ -90,7 +90,7 @@ local function runLootReload(pathArg, printOutput)
 	end
 
 	if pathArg == "--data" then loadLootFileInDir(dataPath)
-	elseif pathArg == "--embedded" then loadLootFileInDir(embedPath)
+	elseif pathArg == "--embedded" then loadLootFileInDir(embeddedPath)
 	elseif pathArg == "--static" then loadLootFileInDir(staticPath)
 	else print("Invalid path argument!") end
 end

--- a/gamemodes/murder/gamemode/sv_loot.lua
+++ b/gamemodes/murder/gamemode/sv_loot.lua
@@ -90,7 +90,7 @@ local function runLootReload(pathArg, printOutput)
 	end
 
 	if pathArg == "--data" then loadLootFileInDir(dataPath)
-	elseif pathArg == "--embedded" then loadLootFileIndir(embedPath)
+	elseif pathArg == "--embedded" then loadLootFileInDir(embedPath)
 	elseif pathArg == "--static" then loadLootFileInDir(staticPath)
 	else print("Invalid path argument!") end
 end


### PR DESCRIPTION
Loot data for maps were sometimes not loading properly. These changes should fix it.

- On game start, attempts to load loot.txt for the current map in the game's "data" addon .gma's "data", and "data_static" directories
- Added command mu_loot_reload, see description on commands.txt