### PR TITLE
Some custom time convars

### DIFF
--- a/gamemodes/murder/content/resource/localization/en/murder.properties
+++ b/gamemodes/murder/content/resource/localization/en/murder.properties
@@ -15,3 +15,5 @@ scoreboard_show_admins=Show admins on scoreboard
 allow_admin_panel=Can admins use admin-panel
 moveafktospectator=Move AFK players to spectators
 show_spectate_info=Show players name and color to spectators
+roundstart_unfreezetime=Time (in seconds) it takes for the round start screen to be hidden
+spectate_delay_after_death=Duration (in seconds) of the "black screen" effect after dying

--- a/gamemodes/murder/gamemode/cl_hud.lua
+++ b/gamemodes/murder/gamemode/cl_hud.lua
@@ -82,7 +82,8 @@ function GM:HUDPaint()
 		else
 
 			if round == 1 then
-				if self.RoundStart && self.RoundStart + 10 > CurTime() then
+				local roundStartUnfreezeTime = GetConVar("mu_roundstart_unfreezetime"):GetFloat()
+				if self.RoundStart && self.RoundStart + roundStartUnfreezeTime > CurTime() then
 					self:DrawStartRoundInformation()
 				else
 					self:DrawGameHUD(LocalPlayer())
@@ -354,7 +355,8 @@ function GM:RenderScreenspaceEffects()
 		self:RenderDeathOverlay()
 	end
 
-	if self:GetRound() == 1 && self.RoundStart && self.RoundStart + 10 > CurTime() then
+	local roundStartUnfreezeTime = GetConVar("mu_roundstart_unfreezetime"):GetFloat()
+	if self:GetRound() == 1 && self.RoundStart && self.RoundStart + roundStartUnfreezeTime > CurTime() then
 		local sw, sh = ScrW(), ScrH()
 		surface.SetDrawColor(0,0,0,255)
 		surface.DrawRect(-1,-1,sw + 2,sh + 2)

--- a/gamemodes/murder/gamemode/cl_respawn.lua
+++ b/gamemodes/murder/gamemode/cl_respawn.lua
@@ -27,7 +27,7 @@ end
 
 GM.SpectateTime = 0
 net.Receive("mu_death", function()
-	GAMEMODE.SpectateTime = CurTime() + net.ReadUInt(4)
+	GAMEMODE.SpectateTime = CurTime() + net.ReadUInt(8)
 end)
 
 function GM:RenderRespawnText()

--- a/gamemodes/murder/gamemode/init.lua
+++ b/gamemodes/murder/gamemode/init.lua
@@ -38,6 +38,7 @@ resource.AddFile("materials/thieves/footprint.vmt")
 resource.AddFile("materials/murder/melon_logo_scoreboard.png")
 
 GM.RoundStartUnfreezeTime = CreateConVar("mu_roundstart_unfreezetime", 10, bit.bor(FCVAR_NOTIFY), "Time (in seconds) it takes for the round start screen to be hidden and players able to move around")
+GM.SpectateDelayAfterDeath = CreateConVar("mu_spectate_delay_after_death", 4, bit.bor(FCVAR_NOTIFY), "Duration (in seconds) of the \"black screen\" effect after dying", 0, 255)
 GM.ShowBystanderTKs = CreateConVar("mu_show_bystander_tks", 1, bit.bor(FCVAR_NOTIFY), "Should show name of killer in chat on a bystander team kill" )
 GM.MurdererFogTime = CreateConVar("mu_murderer_fogtime", 60 * 4, bit.bor(FCVAR_NOTIFY), "Time (in seconds) it takes for a Murderer to show fog for no kills, 0 to disable" )
 GM.TKPenaltyTime = CreateConVar("mu_tk_penalty_time", 20, bit.bor(FCVAR_NOTIFY), "Time (in seconds) for a bystander to be penalised for a team kill" )

--- a/gamemodes/murder/gamemode/init.lua
+++ b/gamemodes/murder/gamemode/init.lua
@@ -37,6 +37,7 @@ include("sv_flashlight.lua")
 resource.AddFile("materials/thieves/footprint.vmt")
 resource.AddFile("materials/murder/melon_logo_scoreboard.png")
 
+GM.RoundStartUnfreezeTime = CreateConVar("mu_roundstart_unfreezetime", 10, bit.bor(FCVAR_NOTIFY), "Time (in seconds) it takes for the round start screen to be hidden and players able to move around")
 GM.ShowBystanderTKs = CreateConVar("mu_show_bystander_tks", 1, bit.bor(FCVAR_NOTIFY), "Should show name of killer in chat on a bystander team kill" )
 GM.MurdererFogTime = CreateConVar("mu_murderer_fogtime", 60 * 4, bit.bor(FCVAR_NOTIFY), "Time (in seconds) it takes for a Murderer to show fog for no kills, 0 to disable" )
 GM.TKPenaltyTime = CreateConVar("mu_tk_penalty_time", 20, bit.bor(FCVAR_NOTIFY), "Time (in seconds) for a bystander to be penalised for a team kill" )

--- a/gamemodes/murder/gamemode/sv_player.lua
+++ b/gamemodes/murder/gamemode/sv_player.lua
@@ -263,12 +263,14 @@ function GM:PlayerDeath(ply, Inflictor, attacker )
 		end
 	end
 
-	ply.NextSpawnTime = CurTime() + 5
+	local spectateDelayAfterDeath = self.SpectateDelayAfterDeath:GetInt()
+
+	ply.NextSpawnTime = CurTime() + spectateDelayAfterDeath + 1
 	ply.DeathTime = CurTime()
-	ply.SpectateTime = CurTime() + 4
+	ply.SpectateTime = CurTime() + spectateDelayAfterDeath
 
 	net.Start("mu_death")
-	net.WriteUInt(4, 4)
+	net.WriteUInt(spectateDelayAfterDeath, 8)
 	net.Send(ply)
 end
 

--- a/gamemodes/murder/gamemode/sv_rounds.lua
+++ b/gamemodes/murder/gamemode/sv_rounds.lua
@@ -272,7 +272,8 @@ function GM:StartNewRound()
 	ct:Add(translate.roundStarted)
 	ct:SendAll()
 
-	self.RoundUnFreezePlayers = CurTime() + 10
+	local roundStartUnfreezeTime = self.RoundStartUnfreezeTime:GetFloat()
+	self.RoundUnFreezePlayers = CurTime() + roundStartUnfreezeTime
 
 	local players = team.GetPlayers(2)
 	for k,ply in pairs(players) do

--- a/gamemodes/murder/murder.txt
+++ b/gamemodes/murder/murder.txt
@@ -146,5 +146,21 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
+
+		18
+		{
+			"name"		"mu_roundstart_unfreezetime"
+			"text"		"roundstart_unfreezetime"
+			"type"		"Numeric"
+			"default"	"10"
+		}
+
+		19
+		{
+			"name"		"mu_spectate_delay_after_death"
+			"text"		"spectate_delay_after_death"
+			"type"		"Numeric"
+			"default"	"4"
+		}
 	}
 }


### PR DESCRIPTION
Made a convar that defines how long players are frozen in the class screen that shows whether you're a bystander or the murderer (`mu_roundstart_unfreezetime`), and another for setting how long a player stays in that "black screen" state after dying (`mu_spectate_delay_after_death`). Those variables can be set both in the console and in the main menu before starting a game.

Didn't add localized texts for Russian and Turkish(?) because I don't speak those languages :)