### PR TITLE
fix error with new convar settings

### DIFF
--- a/gamemodes/murder/gamemode/cl_hud.lua
+++ b/gamemodes/murder/gamemode/cl_hud.lua
@@ -48,6 +48,8 @@ surface.CreateFont( "MersDeathBig" , {
 	italic = false
 })
 
+GM.RoundStartUnfreezeTime = 10
+
 local function drawTextShadow(t,f,x,y,c,px,py)
 	color_black.a = c.a
 	draw.SimpleText(t,f,x + 1,y + 1,color_black,px,py)
@@ -82,8 +84,7 @@ function GM:HUDPaint()
 		else
 
 			if round == 1 then
-				local roundStartUnfreezeTime = GetConVar("mu_roundstart_unfreezetime"):GetFloat()
-				if self.RoundStart && self.RoundStart + roundStartUnfreezeTime > CurTime() then
+				if self.RoundStart && self.RoundStart + self.RoundStartUnfreezeTime > CurTime() then
 					self:DrawStartRoundInformation()
 				else
 					self:DrawGameHUD(LocalPlayer())
@@ -355,8 +356,7 @@ function GM:RenderScreenspaceEffects()
 		self:RenderDeathOverlay()
 	end
 
-	local roundStartUnfreezeTime = GetConVar("mu_roundstart_unfreezetime"):GetFloat()
-	if self:GetRound() == 1 && self.RoundStart && self.RoundStart + roundStartUnfreezeTime > CurTime() then
+	if self:GetRound() == 1 && self.RoundStart && self.RoundStart + self.RoundStartUnfreezeTime > CurTime() then
 		local sw, sh = ScrW(), ScrH()
 		surface.SetDrawColor(0,0,0,255)
 		surface.DrawRect(-1,-1,sw + 2,sh + 2)

--- a/gamemodes/murder/gamemode/cl_rounds.lua
+++ b/gamemodes/murder/gamemode/cl_rounds.lua
@@ -30,6 +30,8 @@ net.Receive("SetRound", function (length)
 		GAMEMODE.StartNewRoundTime = net.ReadDouble()
 	end
 
+	GAMEMODE.RoundStartUnfreezeTime = net.ReadFloat()
+
 	if r == GAMEMODE.Round.Playing then
 		timer.Simple(0.2, function ()
 			local pitch = math.random(70, 140)

--- a/gamemodes/murder/gamemode/sv_rounds.lua
+++ b/gamemodes/murder/gamemode/sv_rounds.lua
@@ -44,6 +44,8 @@ function GM:NetworkRound(ply)
 		net.WriteDouble(self.StartNewRoundTime)
 	end
 
+	net.WriteFloat(self.RoundStartUnfreezeTime:GetFloat())
+
 	if ply == nil then
 		net.Broadcast()
 	else


### PR DESCRIPTION
Turns out you can't really read a server convar from the client unless you're the one hosting it, you'll get an error if you do. Made the server pass mu_roundstart_unfreezetime's value to all clients through the SetRound net message.