### PR TITLE
ConVar for allowing regular players to view the name of players they are spectating

### DIFF
--- a/gamemodes/murder/commands.txt
+++ b/gamemodes/murder/commands.txt
@@ -40,6 +40,7 @@ Server ConVars
 	mu_moveafktospectator <0/1> - Should we move AFK players to spectator on round end
 	mu_show_spectate_info <0/1> - Should show players name and color to spectators
 	mu_roundlimit <number> - Number of rounds we should play before map change
+	mu_spectate_show_names <0/1> - Whether regular players can see player names in spectate mode
 
 Client ConVars
 	mu_debug <0/1> - Shows debug information

--- a/gamemodes/murder/content/resource/localization/en/murder.properties
+++ b/gamemodes/murder/content/resource/localization/en/murder.properties
@@ -15,3 +15,4 @@ scoreboard_show_admins=Show admins on scoreboard
 allow_admin_panel=Can admins use admin-panel
 moveafktospectator=Move AFK players to spectators
 show_spectate_info=Show players name and color to spectators
+spectate_show_names=Whether regular players can see player nicknames in spectate mode

--- a/gamemodes/murder/gamemode/cl_spectate.lua
+++ b/gamemodes/murder/gamemode/cl_spectate.lua
@@ -5,10 +5,15 @@ net.Receive("spectating_status", function (length)
 	GAMEMODE.SpectateMode = net.ReadInt(8)
 	GAMEMODE.Spectating = false
 	GAMEMODE.Spectatee = nil
+
 	if GAMEMODE.SpectateMode >= 0 then
 		GAMEMODE.Spectating = true
 		GAMEMODE.Spectatee = net.ReadEntity()
+	else
+		net.ReadEntity() -- skip over passed entity
 	end
+
+	GAMEMODE.SpectateShowNames = net.ReadBool()
 
 end)
 
@@ -22,6 +27,10 @@ end
 
 function GM:GetCSpectateMode() 
 	return self.SpectateMode
+end
+
+function GM:GetSpectateShowNames()
+	return self.SpectateShowNames
 end
 
 
@@ -39,8 +48,7 @@ function GM:RenderSpectate()
 
 		if IsValid(self:GetCSpectatee()) && self:GetCSpectatee():IsPlayer() then
 			
-
-			if IsValid(LocalPlayer()) && LocalPlayer():IsAdmin() then
+			if self:GetSpectateShowNames() || (IsValid(LocalPlayer()) && LocalPlayer():IsAdmin()) then
 				drawTextShadow(self:GetCSpectatee():Nick(), "MersRadialSmall", ScrW() / 2, ScrH() - 30 - h, Color(190, 190, 190), 1)
 			end
 

--- a/gamemodes/murder/gamemode/init.lua
+++ b/gamemodes/murder/gamemode/init.lua
@@ -37,6 +37,7 @@ include("sv_flashlight.lua")
 resource.AddFile("materials/thieves/footprint.vmt")
 resource.AddFile("materials/murder/melon_logo_scoreboard.png")
 
+GM.SpectateShowNames = CreateConVar("mu_spectate_show_names", 0, bit.bor(FCVAR_NOTIFY), "Whether regular players can see player names in spectate mode")
 GM.ShowBystanderTKs = CreateConVar("mu_show_bystander_tks", 1, bit.bor(FCVAR_NOTIFY), "Should show name of killer in chat on a bystander team kill" )
 GM.MurdererFogTime = CreateConVar("mu_murderer_fogtime", 60 * 4, bit.bor(FCVAR_NOTIFY), "Time (in seconds) it takes for a Murderer to show fog for no kills, 0 to disable" )
 GM.TKPenaltyTime = CreateConVar("mu_tk_penalty_time", 20, bit.bor(FCVAR_NOTIFY), "Time (in seconds) for a bystander to be penalised for a team kill" )

--- a/gamemodes/murder/gamemode/sv_player.lua
+++ b/gamemodes/murder/gamemode/sv_player.lua
@@ -126,7 +126,7 @@ function GM:DoPlayerDeath( ply, attacker, dmginfo )
 
 	local ent = ply:GetNWEntity("DeathRagdoll")
 	if IsValid(ent) then
-		ply:CSpectate(OBS_MODE_CHASE, ent)
+		ply:CSpectate(OBS_MODE_CHASE, ent, self.SpectateShowNames:GetBool())
 		ent:SetBystanderName(ply:GetBystanderName())
 	end
 
@@ -434,7 +434,7 @@ concommand.Add("mu_spectate", function (ply, com, args)
 		ct:Send(ply)
 		return
 	end
-	ply:CSpectate(OBS_MODE_IN_EYE, ent)
+	ply:CSpectate(OBS_MODE_IN_EYE, ent, self.SpectateShowNames:GetBool())
 end)
 
 function GM:PlayerCanSeePlayersChat( text, teamOnly, listener, speaker )

--- a/gamemodes/murder/gamemode/sv_spectate.lua
+++ b/gamemodes/murder/gamemode/sv_spectate.lua
@@ -2,7 +2,7 @@ util.AddNetworkString("spectating_status")
 
 local PlayerMeta = FindMetaTable("Player")
 
-function PlayerMeta:CSpectate(mode, spectatee)
+function PlayerMeta:CSpectate(mode, spectatee, showNames)
 	mode = mode || OBS_MODE_IN_EYE
 	self:Spectate(mode)
 	if IsValid(spectatee) then
@@ -13,9 +13,12 @@ function PlayerMeta:CSpectate(mode, spectatee)
 	end
 	self.SpectateMode = mode
 	self.Spectating = true
+	self.SpectateShowNames = showNames
+	
 	net.Start("spectating_status")
 	net.WriteInt(self.SpectateMode or -1, 8)
 	net.WriteEntity(self.Spectatee or Entity(-1))
+	net.WriteBool(showNames)
 	net.Send(self)
 end
 
@@ -24,9 +27,12 @@ function PlayerMeta:UnCSpectate(mode, spectatee)
 	self.SpectateMode = nil
 	self.Spectatee = nil
 	self.Spectating = false
+	self.SpectateShowNames = showNames
+
 	net.Start("spectating_status")
 	net.WriteInt(-1, 8)
 	net.WriteEntity(Entity(-1))
+	net.WriteBool(showNames)
 	net.Send(self)
 end
 
@@ -64,47 +70,25 @@ function GM:SpectateNext(ply, direction)
 			index = #players
 		end
 
+		local showNames = self.SpectateShowNames:GetBool()
 		local ent = players[index]
 		if IsValid(ent) then
-			ply:CSpectate(OBS_MODE_IN_EYE, ent)
+			ply:CSpectate(OBS_MODE_IN_EYE, ent, showNames)
 		else
 			if IsValid(ply:GetRagdollEntity()) then
 				if ply:GetCSpectating() != ply:GetRagdollEntity() then
-					ply:CSpectate(OBS_MODE_CHASE, ply:GetRagdollEntity())
+					ply:CSpectate(OBS_MODE_CHASE, ply:GetRagdollEntity(), showNames)
 				end
 			else
-				ply:CSpectate(OBS_MODE_ROAMING)
+				ply:CSpectate(OBS_MODE_ROAMING, nil, showNames)
 			end
 		end
 	else
-		ply:CSpectate(OBS_MODE_ROAMING)
+		ply:CSpectate(OBS_MODE_ROAMING, nil, showNames)
 	end
 end
 
 function GM:ChooseSpectatee(ply) 
-
-	-- if ((!ply.SpectateTime || ply.SpectateTime < CurTime()) && ply:KeyPressed(IN_ATTACK))
-	--  || !IsValid(ply:GetCSpectatee()) || (ply:GetCSpectatee():IsPlayer() && !ply:GetCSpectatee():Alive()) then
-
-	-- 	// recalculate spectating
-	-- 	local players = team.GetPlayers(2)
-	-- 	for k,v in pairs(players) do
-	-- 		if !(v:Alive()) then
-	-- 			players[k] = nil
-	-- 		end
-	-- 	end
-
-	-- 	local ent = table.Random(players)
-	-- 	if IsValid(ent) then
-	-- 		ply:CSpectate(OBS_MODE_IN_EYE, ent)
-	-- 	elseif IsValid(ply:IsCSpectating()) then
-	-- 		if ply:GetCSpectating() != ply:GetRagdollEntity() then
-	-- 			ply:CSpectate(OBS_MODE_CHASE, ply:GetRagdollEntity())
-	-- 		end
-	-- 	elseif ply:IsCSpectating() then
-	-- 		ply:CSpectate(OBS_MODE_ROAMING)
-	-- 	end
-	-- end
 
 	if !ply.SpectateTime || ply.SpectateTime < CurTime() then
 

--- a/gamemodes/murder/murder.txt
+++ b/gamemodes/murder/murder.txt
@@ -146,5 +146,13 @@
 			"type"		"CheckBox"
 			"default"	"1"
 		}
+
+		18
+		{
+			"name"		"mu_spectate_show_names"
+			"text"		"spectate_show_names"
+			"type"		"CheckBox"
+			"default"	"0"
+		}
 	}
 }

--- a/gamemodes/murder/murder.txt
+++ b/gamemodes/murder/murder.txt
@@ -153,10 +153,10 @@
 			"text"		"spectate_show_names"
 			"type"		"CheckBox"
 			"default"	"0"
-    }
-    
-    19
-    {
+		}
+		
+		19
+		{
 			"name"		"mu_roundstart_unfreezetime"
 			"text"		"roundstart_unfreezetime"
 			"type"		"Numeric"


### PR DESCRIPTION
Currently you can only see the name of players you're spectating when you're an admin. This newly-added ConVar allows regular players to see their names as well.

I banged my head on the wall way too much over this "can't get server ConVars from client" BS. Gotta admit this code might be looking spaghetti since I didn't wanna change too much what was already there :( but hey! It works and I tested it!