### PR TITLE
Fix runtime edge cases in Murder

### DIFF
--- a/gamemodes/murder/entities/entities/mu_knife/init.lua
+++ b/gamemodes/murder/entities/entities/mu_knife/init.lua
@@ -39,6 +39,8 @@ function ENT:Think()
 	if self.HitSomething && self:GetVelocity():Length2D() < 1.5 then
 		self.HitSomething = false
 		local knife = ents.Create("weapon_mu_knife")
+		if !IsValid(knife) then return end
+
 		knife:SetPos(self:GetPos())
 		knife:SetAngles(self:GetAngles())
 		knife:Spawn()
@@ -73,7 +75,12 @@ function ENT:PhysicsCollide( data, physobj )
 
 		local dmg = DamageInfo()
 		dmg:SetDamage(120)
-		dmg:SetAttacker(self:GetOwner())
+		local attacker = self:GetOwner()
+		if !IsValid(attacker) then
+			attacker = game.GetWorld()
+		end
+		dmg:SetAttacker(attacker)
+		dmg:SetInflictor(self)
 		ply:TakeDamageInfo(dmg)
 		self:EmitSound("physics/flesh/flesh_squishy_impact_hard" .. math.random(1, 4) .. ".wav")
 
@@ -82,6 +89,8 @@ function ENT:PhysicsCollide( data, physobj )
 		addangle(ang, Angle(-60,0,0))
 
 		timer.Simple(0, function ()
+			if !IsValid(ply) then return end
+
 			local rag = ply:GetRagdollEntity()
 
 			if IsValid(rag) then

--- a/gamemodes/murder/entities/entities/mu_loot/init.lua
+++ b/gamemodes/murder/entities/entities/mu_loot/init.lua
@@ -19,6 +19,10 @@ function ENT:Initialize()
 end
 
 function ENT:Use(ply)
+	if self.PickedUp then return end
+	if !IsValid(ply) || !ply:IsPlayer() || !ply:Alive() || ply:Team() != 2 then return end
+
+	self.PickedUp = true
 	local phys = self:GetPhysicsObject()
 	if IsValid(phys) then
 		phys:Wake()

--- a/gamemodes/murder/entities/entities/ttt_traitor_button/init.lua
+++ b/gamemodes/murder/entities/entities/ttt_traitor_button/init.lua
@@ -68,9 +68,10 @@ end
 util.AddNetworkString("TTT_ConfirmUseTButton")
 
 function ENT:TraitorButtonPressed(ply)
-	if self:GetNextUseTime() > CurTime() then
-		return
+	if !self:IsUsable() then
+		return false
 	end
+
 	self:TriggerOutput("OnPressed", ply)
 
 	if self.RemoveOnPress then

--- a/gamemodes/murder/entities/weapons/weapon_mers_base.lua
+++ b/gamemodes/murder/entities/weapons/weapon_mers_base.lua
@@ -162,24 +162,33 @@ end
 
 function SWEP:Think()
 	self:CalculateHoldType()
+	local owner = self:GetOwner()
+	if !IsValid(owner) then
+		self.ReloadHoldStart = nil
+		self.UsingIronsights = false
+		return
+	end
+
 	if self:GetReloadEnd() > 0 && self:GetReloadEnd() < CurTime() then
 		self:SetReloadEnd(0)
 		
 		if self.Primary.InfiniteAmmo then
 			self:SetClip1(self:GetMaxClip1())
 		else
-			local spare = self.Owner:GetAmmoCount(self:GetPrimaryAmmoType())
+			local spare = owner:GetAmmoCount(self:GetPrimaryAmmoType())
 			local addAmmo = math.min(self:GetMaxClip1() - self:Clip1(), spare)
 			self:SetClip1(self:Clip1() + addAmmo)
-			self.Owner:SetAmmo(spare - addAmmo, self:GetPrimaryAmmoType())
+			owner:SetAmmo(spare - addAmmo, self:GetPrimaryAmmoType())
 		end
 	end
 	if self:GetNextIdle() > 0 && self:GetNextIdle() < CurTime() then
 		self:SetNextIdle(0)
 		
 		local sequence = self.SequenceIdle
-		local vm = self.Owner:GetViewModel()
-		vm:SendViewModelMatchingSequence(vm:LookupSequence(sequence))
+		local vm = owner:GetViewModel()
+		if IsValid(vm) then
+			vm:SendViewModelMatchingSequence(vm:LookupSequence(sequence))
+		end
 		if self.Primary.AutoReload then
 			if self:GetMaxClip1() > 0 && self:Clip1() <= 0 then
 				self:Reload()
@@ -187,14 +196,12 @@ function SWEP:Think()
 		end
 	end
 	
-	if IsValid(self.Owner) then
-		if !self.Owner:KeyDown(IN_RELOAD) then
-			self.ReloadHoldStart = nil
-		end
-		self.UsingIronsights = false
-		if self.Owner:KeyDown(IN_ATTACK2) && self:GetWeaponState() != "holster" then
-			self.UsingIronsights = true
-		end
+	if !owner:KeyDown(IN_RELOAD) then
+		self.ReloadHoldStart = nil
+	end
+	self.UsingIronsights = false
+	if owner:KeyDown(IN_ATTACK2) && self:GetWeaponState() != "holster" then
+		self.UsingIronsights = true
 	end
 	
 	self.IronsightsPercent = lerp(self.IronsightsPercent, self.UsingIronsights and 1 or 0, FrameTime() * 2.5)

--- a/gamemodes/murder/entities/weapons/weapon_mu_knife.lua
+++ b/gamemodes/murder/entities/weapons/weapon_mu_knife.lua
@@ -116,6 +116,7 @@ function SWEP:Think()
 	self.BaseClass.Think(self)
 	if self:GetFistHit() != 0 && self:GetFistHit() < RealTime() then
 		self:SetFistHit(0)
+		if !IsValid(self.Owner) then return end
 		if IsFirstTimePredicted() then
 			self:AttackTrace()
 		end
@@ -156,18 +157,21 @@ function SWEP:GetTrace(left, up)
 end
 
 function SWEP:AttackTrace()
-	if self.Owner:IsPlayer() then
-		self.Owner:LagCompensation( true )
+	local owner = self.Owner
+	if !IsValid(owner) then return end
+
+	if owner:IsPlayer() then
+		owner:LagCompensation( true )
 	end
 	local trace = {}
-	trace.filter = self.Owner
-	trace.start = self.Owner:GetShootPos()
+	trace.filter = owner
+	trace.start = owner:GetShootPos()
 	trace.mask = MASK_SHOT_HULL
-	trace.endpos = trace.start + self.Owner:GetAimVector() * self:GetFistRange()
+	trace.endpos = trace.start + owner:GetAimVector() * self:GetFistRange()
 	trace.mins = Vector(-10, -10, -10)
 	trace.maxs = Vector(10, 10, 10)
 	local tr = util.TraceHull(trace)
-	tr.TraceAimVector = self.Owner:GetAimVector()
+	tr.TraceAimVector = owner:GetAimVector()
 
 	// aim around
 	if !IsValid(tr.Entity) then tr = self:GetTrace() end
@@ -183,16 +187,16 @@ function SWEP:AttackTrace()
 			end
 			local dmg = DamageInfo()
 			dmg:SetDamage(self.Primary.Damage or 1)
-			dmg:SetAttacker(self.Owner)
+			dmg:SetAttacker(owner)
 			dmg:SetInflictor(self.Weapon or self)
-			dmg:SetDamageForce(self.Owner:GetAimVector() * self.Primary.Force)
+			dmg:SetDamageForce(owner:GetAimVector() * self.Primary.Force)
 			dmg:SetDamagePosition(tr.HitPos)
 			dmg:SetDamageType(DMG_SLASH)
 			tr.Entity:DispatchTraceAttack(dmg, tr)
 
 			if tr.Entity != self && tr.Entity != self.Owner && (tr.Entity:IsPlayer() || tr.Entity:GetClass() == "prop_ragdoll") then
 				local edata = EffectData()
-				edata:SetStart(self.Owner:GetShootPos())
+				edata:SetStart(owner:GetShootPos())
 				edata:SetOrigin(tr.HitPos)
 				edata:SetNormal(tr.Normal)
 				edata:SetEntity(tr.Entity)
@@ -207,8 +211,8 @@ function SWEP:AttackTrace()
 			self:EmitSound("Weapon_Crowbar.Single")
 		end
 	end
-	if self.Owner:IsPlayer() then
-		self.Owner:LagCompensation( false )
+	if owner:IsPlayer() then
+		owner:LagCompensation( false )
 	end
 end
 
@@ -218,18 +222,25 @@ function SWEP:GetCharge()
 end
 
 function SWEP:ThrowKnife(force)
+	local owner = self.Owner
+	if !IsValid(owner) then return end
+
 	local ent = ents.Create("mu_knife")
-	ent:SetOwner(self.Owner)
-	ent:SetPos(self.Owner:GetShootPos())
-	local knife_ang = Angle(-28,0,0) + self.Owner:EyeAngles()
+	if !IsValid(ent) then return end
+
+	ent:SetOwner(owner)
+	ent:SetPos(owner:GetShootPos())
+	local knife_ang = Angle(-28,0,0) + owner:EyeAngles()
 	knife_ang:RotateAroundAxis(knife_ang:Right(), -90)
 	ent:SetAngles(knife_ang)
 	ent:Spawn()
 
 
 	local phys = ent:GetPhysicsObject()
-	phys:SetVelocity(self.Owner:GetAimVector() * (force * 1000 + 200))
-	phys:AddAngleVelocity(Vector(0, 1500, 0))
+	if IsValid(phys) then
+		phys:SetVelocity(owner:GetAimVector() * (force * 1000 + 200))
+		phys:AddAngleVelocity(Vector(0, 1500, 0))
+	end
 
 	self:Remove()
 end

--- a/gamemodes/murder/gamemode/cl_adminpanel.lua
+++ b/gamemodes/murder/gamemode/cl_adminpanel.lua
@@ -116,7 +116,13 @@ local function doPlayerItems(self, mlist, pteam)
 	end
 	// make sure the rest of the elements are moved up
 	if del then
-		timer.Simple(0, function() mlist:GetCanvas():InvalidateLayout() end)
+		timer.Simple(0, function()
+			if !IsValid(mlist) then return end
+			local canvas = mlist:GetCanvas()
+			if IsValid(canvas) then
+				canvas:InvalidateLayout()
+			end
+		end)
 	end
 end
 
@@ -195,12 +201,13 @@ net.Receive("mu_adminpanel_details", function (ply, length)
 	local json = net.ReadString()
 	local tab = util.JSONToTable(json)
 
-	playerData = tab
+	playerData = istable(tab) and tab or nil
 	-- PrintTable(tab)
 end)
 
 
 concommand.Add("mu_adminpanel", function (client)
+	if !IsValid(client) then return end
 	if !client:IsAdmin() then return end
 	local canUse = GAMEMODE.RoundSettings.AdminPanelAllowed
 	if !canUse then return end

--- a/gamemodes/murder/gamemode/cl_footsteps.lua
+++ b/gamemodes/murder/gamemode/cl_footsteps.lua
@@ -83,7 +83,8 @@ function GM:FootStepsFootstep(ply, pos, foot, sound, volume, filter)
 end
 
 function GM:CanSeeFootsteps()
-	if self:GetAmMurderer() && LocalPlayer():Alive() then return true end
+	local client = LocalPlayer()
+	if IsValid(client) && self:GetAmMurderer() && client:Alive() then return true end
 	return false
 end
 

--- a/gamemodes/murder/gamemode/cl_hud.lua
+++ b/gamemodes/murder/gamemode/cl_hud.lua
@@ -62,6 +62,7 @@ local healthCol = Color(120,255,20)
 function GM:HUDPaint()
 	local round = self:GetRound()
 	local client = LocalPlayer()
+	if !IsValid(client) then return end
 
 	if round == 0 then
 		drawTextShadow(translate.minimumPlayers, "MersRadial", ScrW() / 2, ScrH() - 10, color_white, TEXT_ALIGN_CENTER, TEXT_ALIGN_BOTTOM)
@@ -121,6 +122,8 @@ end
 
 function GM:DrawStartRoundInformation()
 	local client = LocalPlayer()
+	if !IsValid(client) then return end
+
 	local t1 = translate.startHelpBystanderTitle
 	local t2 = nil
 	local c = Color(20,120,255)
@@ -202,12 +205,14 @@ function GM:DrawGameHUD(ply)
 			// find closest button to cursor with usable range
 			local dis, dot, but
 			for k, lbut in pairs(ents.FindByClass("ttt_traitor_button")) do
-				local vec = lbut:GetPos() - ply:GetShootPos()
-				local ldis, ldot = vec:Length(), vec:GetNormal():Dot(ply:GetAimVector())
-				if (ldis < lbut:GetUsableRange() && ldot > 0.95) && (!but || ldot > dot) then
-					dis = ldis
-					dot = ldot
-					but = lbut
+				if lbut:IsUsable() then
+					local vec = lbut:GetPos() - ply:GetShootPos()
+					local ldis, ldot = vec:Length(), vec:GetNormal():Dot(ply:GetAimVector())
+					if (ldis < lbut:GetUsableRange() && ldot > 0.95) && (!but || ldot > dot) then
+						dis = ldis
+						dot = ldot
+						but = lbut
+					end
 				end
 			end
 			
@@ -352,6 +357,8 @@ end
 
 function GM:RenderScreenspaceEffects()
 	local client = LocalPlayer()
+	if !IsValid(client) then return end
+
 	if !client:Alive() then
 		self:RenderDeathOverlay()
 	end

--- a/gamemodes/murder/gamemode/cl_init.lua
+++ b/gamemodes/murder/gamemode/cl_init.lua
@@ -41,16 +41,19 @@ function GM:Think()
 
 			local pos = ply:GetPos() + Vector(0,0,30)
 			local client = LocalPlayer()
+			if !IsValid(client) then continue end
 
 			if ply.FogNextPart < CurTime() then
 
-				if client:GetPos():Distance(pos) > 1000 then return end
+				if client:GetPos():Distance(pos) > 1000 then continue end
 
 				ply.FogEmitter:SetPos(pos)
 				ply.FogNextPart = CurTime() + math.Rand(0.01, 0.03)
 				local vec = Vector(math.Rand(-8, 8), math.Rand(-8, 8), math.Rand(10, 55))
 				local pos = ply:LocalToWorld(vec)
 				local particle = ply.FogEmitter:Add( "particle/snow.vmt", pos)
+				if !particle then continue end
+
 				particle:SetVelocity(  Vector(0,0, 4) + VectorRand() * 3 )
 				particle:SetDieTime( 5 )
 				particle:SetStartAlpha( 180 )

--- a/gamemodes/murder/gamemode/cl_qmenu.lua
+++ b/gamemodes/murder/gamemode/cl_qmenu.lua
@@ -60,6 +60,8 @@ local function addElement(transCode, code)
 end
 
 concommand.Add("+menu", function (client, com, args, full)
+	if !IsValid(client) then return end
+
 	if client:Alive() && client:Team() == 2 then
 		elements = {}
 		addElement("Help", "help")

--- a/gamemodes/murder/gamemode/cl_scoreboard.lua
+++ b/gamemodes/murder/gamemode/cl_scoreboard.lua
@@ -67,6 +67,8 @@ local function addPlayerItem(self, mlist, ply, pteam)
 end
 
 function GM:DoScoreboardActionPopup(ply)
+	if !IsValid(ply) || !ply:IsPlayer() then return end
+
 	local actions = DermaMenu()
 
 	if ply:IsAdmin() then
@@ -104,20 +106,26 @@ function GM:DoScoreboardActionPopup(ply)
 			local spectate = actions:AddOption( Translator:QuickVar(translate.adminMoveToSpectate, "spectate", team.GetName(1)) )
 			spectate:SetIcon( "icon16/status_busy.png" )
 			function spectate:DoClick()
-				RunConsoleCommand("mu_movetospectate", ply:EntIndex())
+				if IsValid(ply) then
+					RunConsoleCommand("mu_movetospectate", ply:EntIndex())
+				end
 			end
 
 			local force = actions:AddOption( translate.adminMurdererForce )
 			force:SetIcon( "icon16/delete.png" )
 			function force:DoClick()
-				RunConsoleCommand("mu_forcenextmurderer", ply:EntIndex())
+				if IsValid(ply) then
+					RunConsoleCommand("mu_forcenextmurderer", ply:EntIndex())
+				end
 			end
 
 			if ply:Alive() then
 				local specateThem = actions:AddOption( translate.adminSpectate )
 				specateThem:SetIcon( "icon16/status_online.png" )
 				function specateThem:DoClick()
-					RunConsoleCommand("mu_spectate", ply:EntIndex())
+					if IsValid(ply) then
+						RunConsoleCommand("mu_spectate", ply:EntIndex())
+					end
 				end
 			end
 		end
@@ -152,7 +160,13 @@ local function doPlayerItems(self, mlist, pteam)
 	end
 	// make sure the rest of the elements are moved up
 	if del then
-		timer.Simple(0, function() mlist:GetCanvas():InvalidateLayout() end)
+		timer.Simple(0, function()
+			if !IsValid(mlist) then return end
+			local canvas = mlist:GetCanvas()
+			if IsValid(canvas) then
+				canvas:InvalidateLayout()
+			end
+		end)
 	end
 end
 

--- a/gamemodes/murder/gamemode/cl_spawns.lua
+++ b/gamemodes/murder/gamemode/cl_spawns.lua
@@ -28,6 +28,8 @@ local function unnetworkList()
 		GAMEMODE.Spawns[i].Pos = pos
 		if !IsValid(GAMEMODE.Spawns[i].Ent) then
 			GAMEMODE.Spawns[i].Ent = ClientsideModel("models/editor/playerstart.mdl")
+			if !IsValid(GAMEMODE.Spawns[i].Ent) then continue end
+
 			GAMEMODE.Spawns[i].Ent:SetAngles(Angle(0, math.random(0, 360), 0))
 		end
 		GAMEMODE.Spawns[i].Ent:SetPos(pos)

--- a/gamemodes/murder/gamemode/sv_bystandername.lua
+++ b/gamemodes/murder/gamemode/sv_bystandername.lua
@@ -79,7 +79,12 @@ function GM:GenerateName(words, sex)
 				table.insert(tab, v.name)
 			end
 		end
-		local word = tab[math.random(#tab)]
+		if #tab <= 0 then
+			for k, v in pairs(self.BystanderNameParts) do
+				table.insert(tab, v.name)
+			end
+		end
+		local word = tab[math.random(#tab)] or "Bystander"
 		if !name then
 			name = word
 		else

--- a/gamemodes/murder/gamemode/sv_loot.lua
+++ b/gamemodes/murder/gamemode/sv_loot.lua
@@ -59,7 +59,7 @@ local function loadLootFileInDir(fileDir)
 	local json = file.Read(filePath, "GAME")
 	local content = util.JSONToTable(json)
 
-	if json then
+	if istable(content) then
 		LootItems = content
 		print("Successfully loaded loot data from "..filePath.."!")
 		return true
@@ -114,6 +114,10 @@ function GM:SpawnLoot()
 end
 
 function GM:SpawnLootItem(data)
+	if !istable(data) || !isstring(data.model) || !isvector(data.pos) || !isangle(data.angle) then
+		return
+	end
+
 	for k, ent in pairs(ents.FindByClass("mu_loot")) do
 		if ent.LootData == data then
 			ent:Remove()
@@ -121,6 +125,8 @@ function GM:SpawnLootItem(data)
 	end
 
 	local ent = ents.Create("mu_loot")
+	if !IsValid(ent) then return end
+
 	ent:SetModel(data.model)
 	ent:SetPos(data.pos)
 	ent:SetAngles(data.angle)
@@ -189,7 +195,9 @@ local function giveMagnum(ply)
 end
 
 function GM:PlayerPickupLoot(ply, ent)
-	ply.LootCollected = ply.LootCollected + 1
+	if !IsValid(ply) || !IsValid(ent) then return end
+
+	ply.LootCollected = (ply.LootCollected or 0) + 1
 
 	if !ply:GetMurderer() then
 		if ply.LootCollected == 5 then
@@ -273,6 +281,11 @@ concommand.Add("mu_loot_add", function (ply, com, args, full)
 	GAMEMODE:SaveLootData()
 
 	local ent = GAMEMODE:SpawnLootItem(data)
+	if !IsValid(ent) then
+		ply:ChatPrint("Failed to spawn loot item")
+		return
+	end
+
 	local mins, maxs = ent:OBBMins(), ent:OBBMaxs()
 	local pos = ent:GetPos()
 	pos.z = pos.z - mins.z

--- a/gamemodes/murder/gamemode/sv_player.lua
+++ b/gamemodes/murder/gamemode/sv_player.lua
@@ -174,6 +174,7 @@ local function getPos(self) return self.pos end
 
 local function generateSpawnEntities(spawnList)
 	local tbl = {}
+	if !istable(spawnList) then return tbl end
 
 	for k, pos in pairs(spawnList) do
 		local t = {}
@@ -510,7 +511,7 @@ local function pressedUse(self, ply)
 		-- find closest button to cursor with usable range
 		local dis, dot, but
 		for k, lbut in pairs(ents.FindByClass("ttt_traitor_button")) do
-			if lbut.TraitorButton then
+			if lbut.TraitorButton && lbut:IsUsable() then
 				local vec = lbut:GetPos() - ply:GetShootPos()
 				local ldis, ldot = vec:Length(), vec:GetNormal():Dot(ply:GetAimVector())
 				if (ldis < lbut:GetUsableRange() && ldot > 0.95) && (!but || ldot > dot) then

--- a/gamemodes/murder/gamemode/sv_ragdoll.lua
+++ b/gamemodes/murder/gamemode/sv_ragdoll.lua
@@ -11,7 +11,7 @@ local function clearupRagdolls(ragdolls, max)
 		if IsValid(rag) then
 			count = count + 1
 		else
-			rag[k] = nil
+			ragdolls[k] = nil
 		end
 	end
 
@@ -50,6 +50,8 @@ function PlayerMeta:CreateRagdoll(attacker, dmginfo)
 	end
 
 	local ent = ents.Create( "prop_ragdoll" )
+	if !IsValid(ent) then return end
+
 	data.ModelScale = 1 // doesn't work on ragdolls
 	duplicator.DoGeneric(ent, data)
 	
@@ -92,13 +94,15 @@ function PlayerMeta:GetRagdollEntity()
 	return self:GetRagdollEntityOld()
 end
 
-if !PlayerMeta.GetRagdollOwnerOld then
-	PlayerMeta.GetRagdollOwnerOld = PlayerMeta.GetRagdollOwner
+if !EntityMeta.GetRagdollOwnerOld then
+	EntityMeta.GetRagdollOwnerOld = EntityMeta.GetRagdollOwner
 end
 function EntityMeta:GetRagdollOwner()
 	local ent = self:GetNWEntity("RagdollOwner")
 	if IsValid(ent) then
 		return ent
 	end
-	return self:GetRagdollOwnerOld()
+	if self.GetRagdollOwnerOld then
+		return self:GetRagdollOwnerOld()
+	end
 end

--- a/gamemodes/murder/gamemode/sv_rounds.lua
+++ b/gamemodes/murder/gamemode/sv_rounds.lua
@@ -156,6 +156,8 @@ end
 // 3 Murderer rage quit
 function GM:EndTheRound(reason, murderer)
 	if self.RoundStage != self.Round.Playing then return end
+	if self.EndingRound then return end
+	self.EndingRound = true
 
 	local players = team.GetPlayers(2)
 	for k, ply in pairs(players) do
@@ -246,18 +248,21 @@ function GM:EndTheRound(reason, murderer)
 
 	self.MurdererLastKill = nil
 
-	hook.Call("OnEndRound")
+	hook.Call("OnEndRound", self)
 	hook.Run("OnEndRoundResult", reason)
 	self.RoundCount = self.RoundCount + 1
 	local limit = self.RoundLimit:GetInt()
 	if limit > 0 then
 		if self.RoundCount >= limit then
-			self:ChangeMap()
-			self:SetRound(4)
-			return
+			if self:ChangeMap() then
+				self:SetRound(4)
+				self.EndingRound = nil
+				return
+			end
 		end
 	end
 	self:SetRound(2)
+	self.EndingRound = nil
 end
 
 function GM:StartNewRound()
@@ -302,8 +307,9 @@ function GM:StartNewRound()
 	// pick a random murderer, weighted
 	local rand = WeightedRandom()
 	for k, ply in pairs(players) do
-		rand:Add(ply.MurdererChance ^ weightMul, ply)
-		ply.MurdererChance = ply.MurdererChance + 1
+		local chance = ply.MurdererChance or 1
+		rand:Add(chance ^ weightMul, ply)
+		ply.MurdererChance = chance + 1
 	end
 	murderer = rand:Roll()
 
@@ -347,7 +353,7 @@ function GM:StartNewRound()
 	self.MurdererLastKill = CurTime()
 
 	self:SetRound(self.Round.Playing)
-	hook.Call("OnStartRound")
+	hook.Call("OnStartRound", self)
 end
 
 function GM:PlayerLeavePlay(ply)
@@ -355,7 +361,7 @@ function GM:PlayerLeavePlay(ply)
 		ply:DropWeapon(ply:GetWeapon("weapon_mu_magnum"))
 	end
 
-	if self.RoundStage == 1 then
+	if self.RoundStage == 1 && !self.EndingRound then
 		if ply:GetMurderer() then
 			self:EndTheRound(3, ply)
 		end
@@ -390,13 +396,16 @@ function GM:ChangeMap()
 				table.insert(prefix, map .. "%.bsp$")
 			end
 			MapVote.Start(nil, nil, nil, prefix)
-			return
+			return true
 		end
-		self:RotateMap()
+		return self:RotateMap()
 	end
+	return false
 end
 
 function GM:RotateMap()
+	if #self.MapList <= 0 then return false end
+
 	local map = game.GetMap()
 	local index 
 	for k, map2 in pairs(self.MapList) do
@@ -418,6 +427,7 @@ function GM:RotateMap()
 	timer.Simple(5, function ()
 		RunConsoleCommand("changelevel", nextMap)
 	end)
+	return true
 end
 
 GM.MapList = {}

--- a/gamemodes/murder/gamemode/sv_spawns.lua
+++ b/gamemodes/murder/gamemode/sv_spawns.lua
@@ -32,8 +32,10 @@ function GM:LoadSpawns()
 		local jason = file.ReadDataAndContent("murder/" .. game.GetMap() .. "/spawns/" .. listName .. ".txt")
 		if jason then
 			local tbl = util.JSONToTable(jason)
-			TeamSpawns[listName] = tbl
-			networkChange(listName)
+			if istable(tbl) then
+				TeamSpawns[listName] = tbl
+				networkChange(listName)
+			end
 		end
 	end
 end

--- a/gamemodes/murder/gamemode/weightedrandom.lua
+++ b/gamemodes/murder/gamemode/weightedrandom.lua
@@ -21,11 +21,13 @@ function WRandom:Roll()
 	for k, item in pairs(self.items) do
 		total = total + item.weight
 	end
-	local c = math.random(total - 1)
+	if total <= 0 then return end
+
+	local c = math.Rand(0, total)
 	local cur = 0
 	for k, item in pairs(self.items) do
 		cur = cur + item.weight
-		if c < cur then
+		if c <= cur then
 			return item.item
 		end
 	end


### PR DESCRIPTION
﻿## Summary
- Fix weighted murderer selection so the first weight bucket can be selected and nil player weights do not crash round start.
- Prevent round-end re-entry and avoid getting stuck in MapSwitch when no map change was scheduled.
- Respect locked TTT traitor buttons on both HUD selection and server-side button activation.
- Add runtime guards around stale players, weapons, projectiles, loot, ragdolls, panels, particles, and malformed spawn/loot data.

## Root cause
Several paths assumed GMod entities, players, panels, and decoded JSON data stayed valid after delayed callbacks, disconnects, map cleanup, or malformed local data. Round transitions also kept the stage as Playing while doing AFK team moves, allowing nested round endings. WeightedRandom used an integer range that excluded the first bucket.

## Validation
- `git diff --check HEAD~1..HEAD`
- Parsed all bundled `data_static` loot/spawn JSON files: 54 parsed, 0 failed
- Static review of touched GLua paths for stale entity, locked button, round transition, and malformed data handling

I did not run a live Garry's Mod server smoke test in this checkout.